### PR TITLE
Forçar funcionamento da classe adicionada quando uma palestra é favor…

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -863,3 +863,7 @@ table tbody tr:nth-child(odd) {
 	background:var(--wp--preset--color--accent-1);
 	color:var(--wp--preset--color--contrast);
 }
+
+.wcb-favourite-session {
+    background: #e0f8ff !important;
+}


### PR DESCRIPTION
…itada.

A classe .wcb-favourite-session  é adicionada numa palestra quando ela é favoritada, entretando nos items de fundo laranja perderam este funcionamento. Forcemos o background com important para garantir o funcionamento.